### PR TITLE
Feat: Implement Clipboard Management Endpoints

### DIFF
--- a/controllers/clipboard.go
+++ b/controllers/clipboard.go
@@ -12,7 +12,11 @@ import (
 	"clipMan/models"
 
 	"github.com/gin-gonic/gin"
+	"math"
+	"strconv"
+
 	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/bson/primitive"
 	"go.mongodb.org/mongo-driver/mongo/options"
 )
 
@@ -76,15 +80,12 @@ func CopyClipboard(c *gin.Context) {
 
 
 func PasteClipboard(c *gin.Context) {
-	var entry models.ClipboardEntry
-
 	userCtx, exists := c.Get("user")
 	if !exists {
 		c.JSON(http.StatusUnauthorized, gin.H{"error": "User not authenticated"})
 		return
 	}
 
-	// Assuming user is a *models.User, extract the user ID
 	authenticatedUser, ok := userCtx.(*models.User)
 	if !ok {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": "Invalid user data"})
@@ -93,24 +94,229 @@ func PasteClipboard(c *gin.Context) {
 
 	collection := database.GetCollection(config.DB_Collection.Entries)
 
-	// Retrieve the most recent clipboard entry
-	opts := options.FindOne().SetSort(bson.D{{"timestamp", -1}})
+	// Pagination parameters
+	pageQuery := c.DefaultQuery("page", "1")
+	limitQuery := c.DefaultQuery("limit", "10")
+
+	page, err := strconv.ParseInt(pageQuery, 10, 64)
+	if err != nil || page < 1 {
+		page = 1
+	}
+	limit, err := strconv.ParseInt(limitQuery, 10, 64)
+	if err != nil || limit < 1 {
+		limit = 10
+	}
+
+	skip := (page - 1) * limit
 
 	filter := bson.D{{"user_id", authenticatedUser.ID}}
-	collection.FindOne(context.TODO(), filter, opts).Decode(&entry)
 
-	if entry.Type == "file" {
-		c.JSON(http.StatusOK, gin.H{
-			"type":     "file",
-			"filename": entry.Filename,
-			"filepath": entry.Filepath,
-			"message":  "Use this path to download the file.",
-		})
-	} else {
-		c.JSON(http.StatusOK, gin.H{
-			"type":    entry.Type,
-			"content": entry.Content,
-		})
+	// Get total count for pagination
+	totalEntries, err := collection.CountDocuments(context.TODO(), filter)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to count entries"})
+		return
 	}
+
+	// Retrieve entries with pagination
+	findOptions := options.Find()
+	findOptions.SetSort(bson.D{{"timestamp", -1}}) // Sort by timestamp descending
+	findOptions.SetSkip(skip)
+	findOptions.SetLimit(limit)
+
+	cursor, err := collection.Find(context.TODO(), filter, findOptions)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to retrieve entries"})
+		return
+	}
+	defer cursor.Close(context.TODO())
+
+	var entries []models.ClipboardEntry
+	if err = cursor.All(context.TODO(), &entries); err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to decode entries"})
+		return
+	}
+
+	if entries == nil {
+		entries = []models.ClipboardEntry{} // Return empty array instead of null
+	}
+
+	c.JSON(http.StatusOK, gin.H{
+		"data": entries,
+		"pagination": gin.H{
+			"total_entries": totalEntries,
+			"current_page":  page,
+			"total_pages":   int64(math.Ceil(float64(totalEntries) / float64(limit))),
+			"limit":         limit,
+		},
+	})
+}
+
+func GetClipboardEntryByID(c *gin.Context) {
+	userCtx, exists := c.Get("user")
+	if !exists {
+		c.JSON(http.StatusUnauthorized, gin.H{"error": "User not authenticated"})
+		return
+	}
+
+	authenticatedUser, ok := userCtx.(*models.User)
+	if !ok {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "Invalid user data"})
+		return
+	}
+
+	entryIDParam := c.Param("id")
+	entryID, err := primitive.ObjectIDFromHex(entryIDParam)
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "Invalid entry ID format"})
+		return
+	}
+
+	collection := database.GetCollection(config.DB_Collection.Entries)
+	var entry models.ClipboardEntry
+
+	filter := bson.M{"_id": entryID, "user_id": authenticatedUser.ID}
+
+	err = collection.FindOne(context.TODO(), filter).Decode(&entry)
+	if err != nil {
+		if err.Error() == "mongo: no documents in result" { // TODO: check for specific error type
+			c.JSON(http.StatusNotFound, gin.H{"error": "Clipboard entry not found or access denied"})
+			return
+		}
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to retrieve entry"})
+		return
+	}
+
+	c.JSON(http.StatusOK, entry)
+}
+
+// UpdateClipboardEntryPayload defines the structure for the PATCH request body
+type UpdateClipboardEntryPayload struct {
+	Content *string `json:"content"`
+	Pinned  *bool   `json:"pinned"`
+	// Add other updatable fields here, e.g., metadata
+}
+
+func UpdateClipboardEntry(c *gin.Context) {
+	userCtx, exists := c.Get("user")
+	if !exists {
+		c.JSON(http.StatusUnauthorized, gin.H{"error": "User not authenticated"})
+		return
+	}
+
+	authenticatedUser, ok := userCtx.(*models.User)
+	if !ok {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "Invalid user data"})
+		return
+	}
+
+	entryIDParam := c.Param("id")
+	entryID, err := primitive.ObjectIDFromHex(entryIDParam)
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "Invalid entry ID format"})
+		return
+	}
+
+	var payload UpdateClipboardEntryPayload
+	if err := c.ShouldBindJSON(&payload); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "Invalid request payload: " + err.Error()})
+		return
+	}
+
+	// Ensure at least one field is being updated
+	if payload.Content == nil && payload.Pinned == nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "No update fields provided"})
+		return
+	}
+
+	collection := database.GetCollection(config.DB_Collection.Entries)
+	var currentEntry models.ClipboardEntry
+
+	// First, verify the entry exists and belongs to the user
+	filter := bson.M{"_id": entryID, "user_id": authenticatedUser.ID}
+	err = collection.FindOne(context.TODO(), filter).Decode(&currentEntry)
+	if err != nil {
+		if err.Error() == "mongo: no documents in result" {
+			c.JSON(http.StatusNotFound, gin.H{"error": "Clipboard entry not found or access denied"})
+			return
+		}
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to retrieve entry for update"})
+		return
+	}
+
+	// Prevent updating fields of a "file" type entry, except for 'pinned'
+	if currentEntry.Type == "file" && payload.Content != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "Cannot update content of a file entry. You can only pin/unpin it."})
+		return
+	}
+
+
+	updateFields := bson.M{}
+	if payload.Content != nil {
+		updateFields["content"] = *payload.Content
+		// If content is updated, also update the timestamp
+		updateFields["timestamp"] = time.Now()
+	}
+	if payload.Pinned != nil {
+		updateFields["pinned"] = *payload.Pinned
+	}
+
+	update := bson.M{"$set": updateFields}
+
+	_, err = collection.UpdateOne(context.TODO(), filter, update)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to update clipboard entry"})
+		return
+	}
+
+	// Fetch the updated entry to return it
+	var updatedEntry models.ClipboardEntry
+	err = collection.FindOne(context.TODO(), filter).Decode(&updatedEntry)
+	if err != nil {
+		// This should ideally not happen if the update was successful
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to retrieve updated entry"})
+		return
+	}
+
+	c.JSON(http.StatusOK, updatedEntry)
+}
+
+func DeleteClipboardEntry(c *gin.Context) {
+	userCtx, exists := c.Get("user")
+	if !exists {
+		c.JSON(http.StatusUnauthorized, gin.H{"error": "User not authenticated"})
+		return
+	}
+
+	authenticatedUser, ok := userCtx.(*models.User)
+	if !ok {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "Invalid user data"})
+		return
+	}
+
+	entryIDParam := c.Param("id")
+	entryID, err := primitive.ObjectIDFromHex(entryIDParam)
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "Invalid entry ID format"})
+		return
+	}
+
+	collection := database.GetCollection(config.DB_Collection.Entries)
+
+	// Construct filter to ensure the entry belongs to the authenticated user
+	filter := bson.M{"_id": entryID, "user_id": authenticatedUser.ID}
+
+	result, err := collection.DeleteOne(context.TODO(), filter)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to delete clipboard entry"})
+		return
+	}
+
+	if result.DeletedCount == 0 {
+		c.JSON(http.StatusNotFound, gin.H{"error": "Clipboard entry not found or access denied"})
+		return
+	}
+
+	c.JSON(http.StatusOK, gin.H{"message": "Clipboard entry deleted successfully"})
 }
 

--- a/models/clipboard.go
+++ b/models/clipboard.go
@@ -14,4 +14,5 @@ type ClipboardEntry struct {
 	Timestamp time.Time `json:"timestamp"`
 	Filepath  string    `json:"filepath,omitempty"`
 	UserId		primitive.ObjectID    `json:"user_id" bson:"user_id"`
+	Pinned    bool      `json:"pinned" bson:"pinned,omitempty"` // Added Pinned field
 }

--- a/routes/clipboard.go
+++ b/routes/clipboard.go
@@ -16,5 +16,8 @@ func SetupClipboardRoutes(r *gin.Engine) {
 			
 	private.POST("/clipboard", controllers.CopyClipboard)
 	private.GET("/clipboard", controllers.PasteClipboard)
+	private.GET("/clipboard/:id", controllers.GetClipboardEntryByID)
+	private.PATCH("/clipboard/:id", controllers.UpdateClipboardEntry)
+	private.DELETE("/clipboard/:id", controllers.DeleteClipboardEntry)
 	
 }


### PR DESCRIPTION
Implemented the following functionalities for the clipboard API:

- GET /api/clipboard:
    - Modified to return all user clips instead of just the latest.
    - Added pagination support with `page` and `limit` query params.
- GET /api/clipboard/:id:
    - New endpoint to retrieve a specific clipboard entry by its ID.
- PATCH /api/clipboard/:id:
    - New endpoint to update a clipboard entry (content for text, pinned status for all).
    - Added `Pinned` field to the `ClipboardEntry` model.
- DELETE /api/clipboard/:id:
    - New endpoint to delete a specific clipboard entry.