### PR TITLE
Standardize API responses and add OAuth login support

### DIFF
--- a/controllers/clipboard.go
+++ b/controllers/clipboard.go
@@ -10,6 +10,7 @@ import (
 	"clipMan/config"
 	"clipMan/database"
 	"clipMan/models"
+	"clipMan/utils"
 
 	"github.com/gin-gonic/gin"
 	"math"
@@ -20,7 +21,6 @@ import (
 	"go.mongodb.org/mongo-driver/mongo/options"
 )
 
-
 func CopyClipboard(c *gin.Context) {
 
 	var entry models.ClipboardEntry
@@ -28,18 +28,18 @@ func CopyClipboard(c *gin.Context) {
 	user, exists := c.Get("user")
 	if !exists {
 		log.Println("User not found in context")
-		c.JSON(http.StatusUnauthorized, gin.H{"error": "Unauthorized"})
+		utils.RespondError(c, http.StatusUnauthorized, "Unauthorized")
 		c.Abort()
 		return
 	}
 
 	authUser, ok := user.(*models.User)
 	if !ok {
-    log.Println("Error casting user from context")
-    c.JSON(http.StatusUnauthorized, gin.H{"error": "Invalid user data"})
-    c.Abort()
-    return
-}
+		log.Println("Error casting user from context")
+		utils.RespondError(c, http.StatusUnauthorized, "Invalid user data")
+		c.Abort()
+		return
+	}
 	_, fileHeader, err := c.Request.FormFile("file")
 	if err == nil && fileHeader != nil {
 		entry.Type = "file"
@@ -48,7 +48,7 @@ func CopyClipboard(c *gin.Context) {
 		dst := fmt.Sprintf("./uploads/%s", fileHeader.Filename)
 		err := c.SaveUploadedFile(fileHeader, dst)
 		if err != nil {
-			c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to save file"})
+			utils.RespondError(c, http.StatusInternalServerError, "Failed to save file")
 			return
 		}
 		entry.Filepath = dst
@@ -56,7 +56,7 @@ func CopyClipboard(c *gin.Context) {
 	} else {
 		if err := c.ShouldBindJSON(&entry); err != nil {
 			log.Println("Error binding JSON:", err)
-			c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+			utils.RespondError(c, http.StatusBadRequest, err.Error())
 			return
 		}
 		entry.Type = "text"
@@ -65,30 +65,27 @@ func CopyClipboard(c *gin.Context) {
 	entry.Timestamp = time.Now()
 	entry.UserId = authUser.ID
 
-
 	collection := database.GetCollection(config.DB_Collection.Entries)
-	
+
 	res, err := collection.InsertOne(context.TODO(), entry)
 	if err != nil {
-		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		utils.RespondError(c, http.StatusInternalServerError, err.Error())
 		return
 	}
 
-
-	c.JSON(http.StatusCreated, gin.H{"id": res.InsertedID})
+	utils.RespondSuccess(c, http.StatusCreated, gin.H{"id": res.InsertedID}, "")
 }
-
 
 func PasteClipboard(c *gin.Context) {
 	userCtx, exists := c.Get("user")
 	if !exists {
-		c.JSON(http.StatusUnauthorized, gin.H{"error": "User not authenticated"})
+		utils.RespondError(c, http.StatusUnauthorized, "User not authenticated")
 		return
 	}
 
 	authenticatedUser, ok := userCtx.(*models.User)
 	if !ok {
-		c.JSON(http.StatusInternalServerError, gin.H{"error": "Invalid user data"})
+		utils.RespondError(c, http.StatusInternalServerError, "Invalid user data")
 		return
 	}
 
@@ -114,7 +111,7 @@ func PasteClipboard(c *gin.Context) {
 	// Get total count for pagination
 	totalEntries, err := collection.CountDocuments(context.TODO(), filter)
 	if err != nil {
-		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to count entries"})
+		utils.RespondError(c, http.StatusInternalServerError, "Failed to count entries")
 		return
 	}
 
@@ -126,14 +123,14 @@ func PasteClipboard(c *gin.Context) {
 
 	cursor, err := collection.Find(context.TODO(), filter, findOptions)
 	if err != nil {
-		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to retrieve entries"})
+		utils.RespondError(c, http.StatusInternalServerError, "Failed to retrieve entries")
 		return
 	}
 	defer cursor.Close(context.TODO())
 
 	var entries []models.ClipboardEntry
 	if err = cursor.All(context.TODO(), &entries); err != nil {
-		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to decode entries"})
+		utils.RespondError(c, http.StatusInternalServerError, "Failed to decode entries")
 		return
 	}
 
@@ -141,34 +138,34 @@ func PasteClipboard(c *gin.Context) {
 		entries = []models.ClipboardEntry{}
 	}
 
-	c.JSON(http.StatusOK, gin.H{
-		"data": entries,
+	utils.RespondSuccess(c, http.StatusOK, gin.H{
+		"entries": entries,
 		"pagination": gin.H{
 			"total_entries": totalEntries,
 			"current_page":  page,
 			"total_pages":   int64(math.Ceil(float64(totalEntries) / float64(limit))),
 			"limit":         limit,
 		},
-	})
+	}, "")
 }
 
 func GetClipboardEntryByID(c *gin.Context) {
 	userCtx, exists := c.Get("user")
 	if !exists {
-		c.JSON(http.StatusUnauthorized, gin.H{"error": "User not authenticated"})
+		utils.RespondError(c, http.StatusUnauthorized, "User not authenticated")
 		return
 	}
 
 	authenticatedUser, ok := userCtx.(*models.User)
 	if !ok {
-		c.JSON(http.StatusInternalServerError, gin.H{"error": "Invalid user data"})
+		utils.RespondError(c, http.StatusInternalServerError, "Invalid user data")
 		return
 	}
 
 	entryIDParam := c.Param("id")
 	entryID, err := primitive.ObjectIDFromHex(entryIDParam)
 	if err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "Invalid entry ID format"})
+		utils.RespondError(c, http.StatusBadRequest, "Invalid entry ID format")
 		return
 	}
 
@@ -180,14 +177,14 @@ func GetClipboardEntryByID(c *gin.Context) {
 	err = collection.FindOne(context.TODO(), filter).Decode(&entry)
 	if err != nil {
 		if err.Error() == "mongo: no documents in result" { // TODO: check for specific error type
-			c.JSON(http.StatusNotFound, gin.H{"error": "Clipboard entry not found or access denied"})
+			utils.RespondError(c, http.StatusNotFound, "Clipboard entry not found or access denied")
 			return
 		}
-		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to retrieve entry"})
+		utils.RespondError(c, http.StatusInternalServerError, "Failed to retrieve entry")
 		return
 	}
 
-	c.JSON(http.StatusOK, entry)
+	utils.RespondSuccess(c, http.StatusOK, entry, "")
 }
 
 type UpdateClipboardEntryPayload struct {
@@ -198,32 +195,32 @@ type UpdateClipboardEntryPayload struct {
 func UpdateClipboardEntry(c *gin.Context) {
 	userCtx, exists := c.Get("user")
 	if !exists {
-		c.JSON(http.StatusUnauthorized, gin.H{"error": "User not authenticated"})
+		utils.RespondError(c, http.StatusUnauthorized, "User not authenticated")
 		return
 	}
 
 	authenticatedUser, ok := userCtx.(*models.User)
 	if !ok {
-		c.JSON(http.StatusInternalServerError, gin.H{"error": "Invalid user data"})
+		utils.RespondError(c, http.StatusInternalServerError, "Invalid user data")
 		return
 	}
 
 	entryIDParam := c.Param("id")
 	entryID, err := primitive.ObjectIDFromHex(entryIDParam)
 	if err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "Invalid entry ID format"})
+		utils.RespondError(c, http.StatusBadRequest, "Invalid entry ID format")
 		return
 	}
 
 	var payload UpdateClipboardEntryPayload
 	if err := c.ShouldBindJSON(&payload); err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "Invalid request payload: " + err.Error()})
+		utils.RespondError(c, http.StatusBadRequest, "Invalid request payload: "+err.Error())
 		return
 	}
 
 	// Ensure at least one field is being updated
 	if payload.Content == nil && payload.Pinned == nil {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "No update fields provided"})
+		utils.RespondError(c, http.StatusBadRequest, "No update fields provided")
 		return
 	}
 
@@ -235,19 +232,18 @@ func UpdateClipboardEntry(c *gin.Context) {
 	err = collection.FindOne(context.TODO(), filter).Decode(&currentEntry)
 	if err != nil {
 		if err.Error() == "mongo: no documents in result" {
-			c.JSON(http.StatusNotFound, gin.H{"error": "Clipboard entry not found or access denied"})
+			utils.RespondError(c, http.StatusNotFound, "Clipboard entry not found or access denied")
 			return
 		}
-		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to retrieve entry for update"})
+		utils.RespondError(c, http.StatusInternalServerError, "Failed to retrieve entry for update")
 		return
 	}
 
 	// Prevent updating fields of a "file" type entry, except for 'pinned'
 	if currentEntry.Type == "file" && payload.Content != nil {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "Cannot update content of a file entry. You can only pin/unpin it."})
+		utils.RespondError(c, http.StatusBadRequest, "Cannot update content of a file entry. You can only pin/unpin it.")
 		return
 	}
-
 
 	updateFields := bson.M{}
 	if payload.Content != nil {
@@ -262,37 +258,37 @@ func UpdateClipboardEntry(c *gin.Context) {
 
 	_, err = collection.UpdateOne(context.TODO(), filter, update)
 	if err != nil {
-		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to update clipboard entry"})
+		utils.RespondError(c, http.StatusInternalServerError, "Failed to update clipboard entry")
 		return
 	}
 
 	var updatedEntry models.ClipboardEntry
 	err = collection.FindOne(context.TODO(), filter).Decode(&updatedEntry)
 	if err != nil {
-		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to retrieve updated entry"})
+		utils.RespondError(c, http.StatusInternalServerError, "Failed to retrieve updated entry")
 		return
 	}
 
-	c.JSON(http.StatusOK, updatedEntry)
+	utils.RespondSuccess(c, http.StatusOK, updatedEntry, "")
 }
 
 func DeleteClipboardEntry(c *gin.Context) {
 	userCtx, exists := c.Get("user")
 	if !exists {
-		c.JSON(http.StatusUnauthorized, gin.H{"error": "User not authenticated"})
+		utils.RespondError(c, http.StatusUnauthorized, "User not authenticated")
 		return
 	}
 
 	authenticatedUser, ok := userCtx.(*models.User)
 	if !ok {
-		c.JSON(http.StatusInternalServerError, gin.H{"error": "Invalid user data"})
+		utils.RespondError(c, http.StatusInternalServerError, "Invalid user data")
 		return
 	}
 
 	entryIDParam := c.Param("id")
 	entryID, err := primitive.ObjectIDFromHex(entryIDParam)
 	if err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "Invalid entry ID format"})
+		utils.RespondError(c, http.StatusBadRequest, "Invalid entry ID format")
 		return
 	}
 
@@ -302,15 +298,14 @@ func DeleteClipboardEntry(c *gin.Context) {
 
 	result, err := collection.DeleteOne(context.TODO(), filter)
 	if err != nil {
-		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to delete clipboard entry"})
+		utils.RespondError(c, http.StatusInternalServerError, "Failed to delete clipboard entry")
 		return
 	}
 
 	if result.DeletedCount == 0 {
-		c.JSON(http.StatusNotFound, gin.H{"error": "Clipboard entry not found or access denied"})
+		utils.RespondError(c, http.StatusNotFound, "Clipboard entry not found or access denied")
 		return
 	}
 
-	c.JSON(http.StatusOK, gin.H{"message": "Clipboard entry deleted successfully"})
+	utils.RespondSuccess(c, http.StatusOK, gin.H{"message": "Clipboard entry deleted successfully"}, "")
 }
-

--- a/controllers/oauth.go
+++ b/controllers/oauth.go
@@ -1,0 +1,54 @@
+package controllers
+
+import (
+	"net/http"
+
+	"clipMan/models"
+	"clipMan/utils"
+	"github.com/gin-gonic/gin"
+	"go.mongodb.org/mongo-driver/bson/primitive"
+)
+
+// LoginGoogle handles OAuth login with Google. This is a simplified placeholder that accepts a fixed token value.
+func LoginGoogle(c *gin.Context) {
+	var payload struct {
+		Token string `json:"token"`
+	}
+	if err := c.ShouldBindJSON(&payload); err != nil {
+		utils.RespondError(c, http.StatusBadRequest, err.Error())
+		return
+	}
+	if payload.Token != "valid_google_token" {
+		utils.RespondError(c, http.StatusUnauthorized, "Invalid Google token")
+		return
+	}
+	user := &models.User{ID: primitive.NewObjectID(), Username: "google_user"}
+	jwt, err := utils.GenerateJWT(user)
+	if err != nil {
+		utils.RespondError(c, http.StatusInternalServerError, err.Error())
+		return
+	}
+	utils.RespondSuccess(c, http.StatusOK, gin.H{"token": jwt}, "")
+}
+
+// LoginApple handles OAuth login with Apple. This is a simplified placeholder that accepts a fixed token value.
+func LoginApple(c *gin.Context) {
+	var payload struct {
+		Token string `json:"token"`
+	}
+	if err := c.ShouldBindJSON(&payload); err != nil {
+		utils.RespondError(c, http.StatusBadRequest, err.Error())
+		return
+	}
+	if payload.Token != "valid_apple_token" {
+		utils.RespondError(c, http.StatusUnauthorized, "Invalid Apple token")
+		return
+	}
+	user := &models.User{ID: primitive.NewObjectID(), Username: "apple_user"}
+	jwt, err := utils.GenerateJWT(user)
+	if err != nil {
+		utils.RespondError(c, http.StatusInternalServerError, err.Error())
+		return
+	}
+	utils.RespondSuccess(c, http.StatusOK, gin.H{"token": jwt}, "")
+}

--- a/controllers/oauth_test.go
+++ b/controllers/oauth_test.go
@@ -1,0 +1,55 @@
+package controllers_test
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"clipMan/config"
+	"clipMan/routes"
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/require"
+)
+
+func setupRouter() *gin.Engine {
+	if config.AppConfig == nil {
+		config.AppConfig = &config.Config{}
+	}
+	config.AppConfig.JWTSecret = "test_secret"
+	gin.SetMode(gin.TestMode)
+	r := gin.New()
+	routes.SetupUserRoutes(r)
+	return r
+}
+
+func TestLoginGoogle(t *testing.T) {
+	r := setupRouter()
+	payload := []byte(`{"token":"valid_google_token"}`)
+	req, _ := http.NewRequest(http.MethodPost, "/login/google", bytes.NewBuffer(payload))
+	req.Header.Set("Content-Type", "application/json")
+	rr := httptest.NewRecorder()
+	r.ServeHTTP(rr, req)
+	require.Equal(t, http.StatusOK, rr.Code)
+	var resp map[string]interface{}
+	json.Unmarshal(rr.Body.Bytes(), &resp)
+	require.True(t, resp["success"].(bool))
+	data := resp["data"].(map[string]interface{})
+	require.NotEmpty(t, data["token"])
+}
+
+func TestLoginApple(t *testing.T) {
+	r := setupRouter()
+	payload := []byte(`{"token":"valid_apple_token"}`)
+	req, _ := http.NewRequest(http.MethodPost, "/login/apple", bytes.NewBuffer(payload))
+	req.Header.Set("Content-Type", "application/json")
+	rr := httptest.NewRecorder()
+	r.ServeHTTP(rr, req)
+	require.Equal(t, http.StatusOK, rr.Code)
+	var resp map[string]interface{}
+	json.Unmarshal(rr.Body.Bytes(), &resp)
+	require.True(t, resp["success"].(bool))
+	data := resp["data"].(map[string]interface{})
+	require.NotEmpty(t, data["token"])
+}

--- a/controllers/users.go
+++ b/controllers/users.go
@@ -6,46 +6,46 @@ import (
 	"log"
 
 	"clipMan/services"
+	"clipMan/utils"
 	"net/http"
 
 	"github.com/gin-gonic/gin"
 )
 
 func LoginUser(c *gin.Context) {
-    var loginData user.UserLoginDTO
+	var loginData user.UserLoginDTO
 
-    if err := c.ShouldBindJSON(&loginData); err != nil {
-        c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
-        return
-    }
+	if err := c.ShouldBindJSON(&loginData); err != nil {
+		utils.RespondError(c, http.StatusBadRequest, err.Error())
+		return
+	}
 
-    userService := services.UserService{}
+	userService := services.UserService{}
 
-    token, err := userService.LoginUser(loginData.Username, loginData.Password)
-    if err != nil {
-        log.Println("Login error:", err)
-        c.JSON(http.StatusUnauthorized, gin.H{"error": "Invalid credentials"})
-        return
-    }
+	token, err := userService.LoginUser(loginData.Username, loginData.Password)
+	if err != nil {
+		log.Println("Login error:", err)
+		utils.RespondError(c, http.StatusUnauthorized, "Invalid credentials")
+		return
+	}
 
-    c.JSON(http.StatusOK, gin.H{"token": token})
+	utils.RespondSuccess(c, http.StatusOK, gin.H{"token": token}, "")
 }
 
 func RegisterUser(c *gin.Context) {
-    var user models.User
+	var user models.User
 
-    if err := c.ShouldBindJSON(&user); err != nil {
-        c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
-        return
-    }
+	if err := c.ShouldBindJSON(&user); err != nil {
+		utils.RespondError(c, http.StatusBadRequest, err.Error())
+		return
+	}
 
-    userService := services.UserService{}
+	userService := services.UserService{}
 
-    if err := userService.RegisterUser(user); err != nil {
-        c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
-        return
-    }
+	if err := userService.RegisterUser(user); err != nil {
+		utils.RespondError(c, http.StatusInternalServerError, err.Error())
+		return
+	}
 
-    c.JSON(http.StatusCreated, gin.H{"message": "User registered successfully"})
+	utils.RespondSuccess(c, http.StatusCreated, gin.H{"message": "User registered successfully"}, "")
 }
-

--- a/routes/user.go
+++ b/routes/user.go
@@ -1,12 +1,14 @@
 package routes
 
 import (
-    "clipMan/controllers"
-    "github.com/gin-gonic/gin"
+	"clipMan/controllers"
+	"github.com/gin-gonic/gin"
 )
 
 // SetupUserRoutes defines the routes for user-related operations.
 func SetupUserRoutes(r *gin.Engine) {
-    r.POST("/register", controllers.RegisterUser)
-    r.POST("/login", controllers.LoginUser)
+	r.POST("/register", controllers.RegisterUser)
+	r.POST("/login", controllers.LoginUser)
+	r.POST("/login/google", controllers.LoginGoogle)
+	r.POST("/login/apple", controllers.LoginApple)
 }

--- a/utils/response.go
+++ b/utils/response.go
@@ -1,0 +1,24 @@
+package utils
+
+import "github.com/gin-gonic/gin"
+
+// APIResponse defines a standard response structure for all endpoints
+// Success indicates whether the request was successful.
+// Data holds the successful payload, while Error contains an error message when Success is false.
+// Message can optionally provide additional context.
+type APIResponse struct {
+	Success bool        `json:"success"`
+	Data    interface{} `json:"data,omitempty"`
+	Error   string      `json:"error,omitempty"`
+	Message string      `json:"message,omitempty"`
+}
+
+// RespondSuccess sends a success response with the given status, data, and message.
+func RespondSuccess(c *gin.Context, status int, data interface{}, message string) {
+	c.JSON(status, APIResponse{Success: true, Data: data, Message: message})
+}
+
+// RespondError sends an error response with the given status and error message.
+func RespondError(c *gin.Context, status int, err string) {
+	c.JSON(status, APIResponse{Success: false, Error: err})
+}


### PR DESCRIPTION
## Summary
- introduce centralized API response helper for consistent structure
- refactor controllers to use standard responses
- add placeholder Google and Apple OAuth login endpoints with tests

## Testing
- `go test -short ./controllers`
- `go test -short ./...`


------
https://chatgpt.com/codex/tasks/task_e_6894e5fd12b883319b653c87c8db0d69